### PR TITLE
Updated Sysadmin and UserCmd help strings

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -689,8 +689,10 @@ class Sysadmin(CkanCommand):
                                       (prompts for password and email if not
                                       supplied).
                                       Field can be: apikey
-                                                    password
                                                     email
+                                                    fullname
+                                                    name (this will be the username)
+                                                    password
       sysadmin remove USERNAME      - removes user from sysadmins
     '''
 
@@ -776,8 +778,10 @@ class UserCmd(CkanCommand):
                                       - add a user (prompts for email and
                                         password if not supplied).
                                         Field can be: apikey
-                                                      password
                                                       email
+                                                      fullname
+                                                      name (this will be the username)
+                                                      password
       user setpass USERNAME           - set user password (prompts)
       user remove USERNAME            - removes user from users
       user search QUERY               - searches for a user name


### PR DESCRIPTION
Added name and fullname to the help strings for both the Sysadmin and UserCmd commands

Fixes #
https://github.com/ckan/ckan/issues/5002

### Proposed fixes:
Added name and fullname to help strings

### Features:

- [ ] includes tests covering changes
- [ X ] includes updated documentation
- [ X ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
